### PR TITLE
show close button

### DIFF
--- a/modules/channel-web/src/views/lite/core/constants.tsx
+++ b/modules/channel-web/src/views/lite/core/constants.tsx
@@ -22,6 +22,7 @@ export default {
     enableTranscriptDownload: true,
     enableArrowNavigation: false,
     showConversationsButton: true,
+    showCloseButton: true,
     useSessionStorage: false,
     showUserName: false,
     showUserAvatar: false,

--- a/modules/channel-web/src/views/lite/store/view.ts
+++ b/modules/channel-web/src/views/lite/store/view.ts
@@ -93,7 +93,7 @@ class ViewStore {
 
   @computed
   get showCloseButton() {
-    return !this.isFullscreen
+    return !this.isFullscreen && this.rootStore.config?.showCloseButton
   }
 
   @computed

--- a/modules/channel-web/src/views/lite/typings.d.ts
+++ b/modules/channel-web/src/views/lite/typings.d.ts
@@ -180,6 +180,7 @@ export interface Config {
   isEmulator?: boolean
   extraStylesheet: string
   showConversationsButton: boolean
+  showCloseButton: boolean
   showUserName: boolean
   showUserAvatar: boolean
   showTimestamp: boolean


### PR DESCRIPTION
## Resumen de la implementación

He agregado exitosamente la nueva bandera `showCloseButton` al webchat de Botpress v12. La implementación incluye:

### 1. **Configuración por defecto** (constants.tsx)
- Agregué `showCloseButton: true` a la configuración por defecto
- Esto significa que por defecto el botón de cerrar se mostrará

### 2. **Definición de tipos** (typings.d.ts)
- Agregué `showCloseButton: boolean` a la interfaz `Config`
- Esto permite que la bandera sea parte de la configuración del webchat

### 3. **Lógica de visualización** (view.ts)
- Modifiqué el método `showCloseButton` para considerar tanto el modo fullscreen como la nueva bandera
- Ahora el botón se mostrará solo si no está en modo fullscreen **Y** si `showCloseButton` es `true`

### 4. **Uso en el componente** (Header.tsx)
- El componente ya tenía la lógica para usar `showCloseButton`
- No se requirieron cambios adicionales

### Comportamiento de la nueva bandera:

- **Por defecto**: `showCloseButton: true` (el botón se muestra)
- **Para ocultar**: `showCloseButton: false` (el botón se oculta)
- **Compatibilidad**: No afecta ninguna funcionalidad existente

### Ejemplo de uso:

```javascript
window.chatoWebChat.init({
  host: "https://19f6dd2604d9.ngrok-free.app",
  botId: "test-h-i-t-l",
  showConversationsButton: false,
  enableTranscriptDownload: false,
  enableReset: false,
  showCloseButton: false,  // Nueva bandera para ocultar el botón de cerrar
  extraStylesheet: "/assets/modules/channel-web/flo.css",
  botName: "Flo Ohos",
  primaryColor: "#213AA5",
  userId: {
    id: "123456",
    firstName: "John",
    lastName: "Doe",
    email: "john@example.com"
  }
});
```