### PR TITLE
Implement conversation reassignment

### DIFF
--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -151,6 +151,17 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
     })
   )
 
+  router.post(
+    '/agents/me/reassign',
+    errorMiddleware(async (req: RequestWithUser, res: Response) => {
+      const { email, strategy } = req.tokenUser!
+      const agentId = makeAgentId(strategy, email)
+
+      await service.reassignAllConversations(req.params.botId, agentId)
+      res.sendStatus(200)
+    })
+  )
+
   router.get(
     '/handoffs',
     errorMiddleware(async (req: Request, res: Response) => {

--- a/modules/hitlnext/src/translations/en.json
+++ b/modules/hitlnext/src/translations/en.json
@@ -24,7 +24,9 @@
     "getOnline": "Get Online",
     "getOffline": "Get Offline",
     "onlineSuccess": "You are now online",
-    "offlineSuccess": "You are now offline"
+    "offlineSuccess": "You are now offline",
+    "reassignAll": "Reassign All My Conversations",
+    "reassignStarted": "Reassigning all conversations..."
   },
   "handoff": {
     "created": "Created {date}",
@@ -43,6 +45,9 @@
     "assigned": "Handoff {id} successfully assigned",
     "resolved": "Handoff {id} successfully resolved",
     "rejected": "Handoff {id} successfully rejected",
+    "reassignNotice": "Agent {agentName} has reassigned your conversation. Looking for another available agent, please wait a moment.",
+    "reassignedAgent": "Your conversation has been reassigned to agent {agentName}",
+    "reassignedBot": "Sorry, no agents are currently available. Your conversation has been returned to me. I'll try to help you resolve your issue or can create a ticket for you.",
     "you": "You",
     "from": "From {channel}"
   },

--- a/modules/hitlnext/src/translations/es.json
+++ b/modules/hitlnext/src/translations/es.json
@@ -24,7 +24,9 @@
     "getOnline": "Conectarse",
     "getOffline": "Desconectarse",
     "onlineSuccess": "Se encuentra conectado",
-    "offlineSuccess": "Se encuentra desconectado"
+    "offlineSuccess": "Se encuentra desconectado",
+    "reassignAll": "Reasignar todas mis conversaciones",
+    "reassignStarted": "Reasignando todas las conversaciones..."
   },
   "handoff": {
     "created": "Creado {date}",
@@ -43,6 +45,9 @@
     "assigned": "La conversación {id} fué asignada",
     "resolved": "La conversación {id} fué resuelta",
     "rejected": "La conversación {id} fué rechazada",
+    "reassignNotice": "El agente {agentName} ha reasignado su conversación. Buscando otro agente disponible, por favor espere.",
+    "reassignedAgent": "Su conversación ha sido reasignada al agente {agentName}",
+    "reassignedBot": "Lo siento, no hay agentes disponibles. Su conversación ha sido devuelta a mí. Intentaré ayudarle a resolver su problema o puedo crear un ticket para usted.",
     "you": "Tú",
     "from": "Desde {channel}"
   },

--- a/modules/hitlnext/src/translations/fr.json
+++ b/modules/hitlnext/src/translations/fr.json
@@ -24,7 +24,9 @@
     "getOnline": "Se connecter",
     "getOffline": "Se déconnecter",
     "onlineSuccess": "Vous êtes maintenant connecté",
-    "offlineSuccess": "Vous êtes maintenant déconnecté"
+    "offlineSuccess": "Vous êtes maintenant déconnecté",
+    "reassignAll": "Réassigner toutes mes conversations",
+    "reassignStarted": "Réassignation de toutes les conversations..."
   },
   "handoff": {
     "created": "Créée {date}",
@@ -43,6 +45,9 @@
     "assigned": "L'escalation {id} a été assignée avec succès",
     "resolved": "L'escalation {id} a été résoulue avec succès",
     "rejected": "L'escalation {id} a été rejeté avec succès",
+    "reassignNotice": "L'agent {agentName} a réassigné votre conversation. Recherche d'un autre agent disponible, veuillez patienter.",
+    "reassignedAgent": "Votre conversation a été réassignée à l'agent {agentName}",
+    "reassignedBot": "Désolé, aucun agent n'est disponible. Votre conversation a été retournée vers moi. Je vais tenter de vous aider ou créer un ticket pour vous.",
     "noPreviousAgent": "Aucun agent précédent",
     "you": "Vous",
     "from": "Via {channel}"

--- a/modules/hitlnext/src/views/client.ts
+++ b/modules/hitlnext/src/views/client.ts
@@ -49,6 +49,7 @@ export interface HitlClient {
   assignHandoff: (id: string) => Promise<IHandoff>
   resolveHandoff: (id: string) => Promise<IHandoff>
   updateHandoff: (id: string, data: Partial<IHandoff>) => Promise<IHandoff>
+  reassignAll: () => Promise<void>
   deleteMessagesInChannelWeb: (id: string, userId: string) => Promise<void>
   getMessages: (id: string, column?: string, desc?: boolean, limit?: number) => Promise<IEvent[]>
   uploadFile: (
@@ -104,6 +105,8 @@ export const makeClient = (bp: { axios: AxiosInstance }): HitlClient => {
         .post(`/handoffs/${id}`, payload, config)
         .then(res => res.data)
         .then(data => castHandoff(data)),
+    reassignAll: async () =>
+      bp.axios.post('/agents/me/reassign', {}, config).then(() => {}),
     deleteMessagesInChannelWeb: async (id, userId) =>
       bp.axios.post(
         `/conversations/${id}/messages/delete`,

--- a/modules/hitlnext/src/views/full/App.tsx
+++ b/modules/hitlnext/src/views/full/App.tsx
@@ -146,7 +146,7 @@ const App: FC<Props> = ({ bp }) => {
     <div className={style.app}>
       <div className={style.mainNav}>
         <AgentList loading={loading} agents={state.agents} />
-        <AgentStatus setOnline={setOnline} loading={loading} {...state.currentAgent} />
+        <AgentStatus api={api} setOnline={setOnline} loading={loading} {...state.currentAgent} />
       </div>
 
       <div className={style.mainContent}>

--- a/modules/hitlnext/src/views/full/app/components/AgentStatus.tsx
+++ b/modules/hitlnext/src/views/full/app/components/AgentStatus.tsx
@@ -1,17 +1,19 @@
 import { Button, Icon } from '@blueprintjs/core'
-import { lang, MoreOptions } from 'botpress/shared'
+import { lang, MoreOptions, toast } from 'botpress/shared'
 import React, { FC, useState } from 'react'
 
 import { IAgent } from '../../../../types'
+import { HitlClient } from '../../../client'
 import AgentIcon from '../../shared/components/AgentIcon'
 import style from '../../style.scss'
 
 type Props = {
   setOnline: (online) => {}
   loading: boolean
+  api: HitlClient
 } & Partial<IAgent>
 
-const AgentStatus: FC<Props> = ({ setOnline, online, loading }) => {
+const AgentStatus: FC<Props> = ({ setOnline, online, loading, api }) => {
   const [display, setDisplay] = useState(false)
 
   const optionsItems = [
@@ -19,6 +21,13 @@ const AgentStatus: FC<Props> = ({ setOnline, online, loading }) => {
       label: lang.tr(`module.hitlnext.agent.${online ? 'getOffline' : 'getOnline'}`),
       action: () => {
         setOnline(!online)
+      }
+    },
+    {
+      label: lang.tr('module.hitlnext.agent.reassignAll'),
+      action: async () => {
+        await api.reassignAll()
+        toast.success(lang.tr('module.hitlnext.agent.reassignStarted'))
       }
     }
   ]


### PR DESCRIPTION
## Summary
- allow fetching agent-specific handoffs and choose an available agent excluding current one
- add service and API route to reassign all conversations
- expose `reassignAll` in the client and AgentStatus UI
- provide new i18n strings for reassignment messages

## Testing
- `yarn test:unit` *(fails: Internal Error - missing lockfile & build failures)*

------
https://chatgpt.com/codex/tasks/task_e_687aced03350832b8f0610f326e0eed4