### PR TITLE
last message

### DIFF
--- a/modules/hitlnext/src/backend/repository.ts
+++ b/modules/hitlnext/src/backend/repository.ts
@@ -189,7 +189,7 @@ export default class Repository {
   // To get the most recent event, we assume the 'Id' column is ordered;
   // thus meaning the highest Id is also the most recent.
   //
-  // - Note: We're interested in 'incoming' & 'text' events only
+  // - Note: We're interested in 'incoming' events (text, image, file, etc.)
   private recentEventQuery() {
     return this.bp
       .database<sdk.IO.StoredEvent>('events')
@@ -198,7 +198,7 @@ export default class Repository {
         this.whereIn('id', function() {
           this.max('id')
             .from('events')
-            .where('type', 'text')
+            .whereIn('type', ['text', 'image', 'file', 'audio', 'video', 'location', 'carousel', 'quick_reply'])
             .andWhere('direction', 'incoming')
             .groupBy('threadId')
         })

--- a/modules/hitlnext/src/translations/en.json
+++ b/modules/hitlnext/src/translations/en.json
@@ -28,6 +28,15 @@
   },
   "handoff": {
     "created": "Created {date}",
+    "noMessage": "No message available",
+    "imageMessage": "Image",
+    "fileMessage": "File",
+    "audioMessage": "Audio",
+    "videoMessage": "Video",
+    "locationMessage": "Location",
+    "quickReply": "Quick reply",
+    "carouselMessage": "Carousel",
+    "unknownMessage": "Message",
     "contactDetails": "Contact Details",
     "status": {
       "pending": "pending",

--- a/modules/hitlnext/src/translations/es.json
+++ b/modules/hitlnext/src/translations/es.json
@@ -28,6 +28,15 @@
   },
   "handoff": {
     "created": "Creado {date}",
+    "noMessage": "Sin mensaje disponible",
+    "imageMessage": "Imagen",
+    "fileMessage": "Archivo",
+    "audioMessage": "Audio",
+    "videoMessage": "Video",
+    "locationMessage": "Ubicación",
+    "quickReply": "Respuesta rápida",
+    "carouselMessage": "Carrusel",
+    "unknownMessage": "Mensaje",
     "contactDetails": "Detalles del Contacto",
     "status": {
       "pending": "pendiente",

--- a/modules/hitlnext/src/translations/fr.json
+++ b/modules/hitlnext/src/translations/fr.json
@@ -28,6 +28,15 @@
   },
   "handoff": {
     "created": "Créée {date}",
+    "noMessage": "Aucun message disponible",
+    "imageMessage": "Image",
+    "fileMessage": "Fichier",
+    "audioMessage": "Audio",
+    "videoMessage": "Vidéo",
+    "locationMessage": "Localisation",
+    "quickReply": "Réponse rapide",
+    "carouselMessage": "Carrousel",
+    "unknownMessage": "Message",
     "contactDetails": "Détails du contact",
     "status": {
       "pending": "en attente",

--- a/modules/hitlnext/src/views/full/studio-sidebar/components/HandoffItem.tsx
+++ b/modules/hitlnext/src/views/full/studio-sidebar/components/HandoffItem.tsx
@@ -19,12 +19,67 @@ const HandoffItem: FC<IHandoff> = props => {
     return () => clearInterval(interval)
   }, [])
 
+  // Extract the last message text from the user conversation
+  const getLastMessageText = () => {
+    if (!props.userConversation || !props.userConversation.event) {
+      return lang.tr('module.hitlnext.handoff.noMessage')
+    }
+
+    const event = props.userConversation.event
+    let text = ''
+
+    // Handle different event types
+    switch (event.type) {
+      case 'text':
+        text = event.preview || (event.payload && event.payload.text) || ''
+        break
+      case 'image':
+        text = '📷 ' + (lang.tr('module.hitlnext.handoff.imageMessage') || 'Image')
+        break
+      case 'file':
+        text = '📎 ' + (lang.tr('module.hitlnext.handoff.fileMessage') || 'File')
+        break
+      case 'audio':
+        text = '🎵 ' + (lang.tr('module.hitlnext.handoff.audioMessage') || 'Audio')
+        break
+      case 'video':
+        text = '🎥 ' + (lang.tr('module.hitlnext.handoff.videoMessage') || 'Video')
+        break
+      case 'location':
+        text = '📍 ' + (lang.tr('module.hitlnext.handoff.locationMessage') || 'Location')
+        break
+      case 'quick_reply':
+        text = event.preview || (event.payload && event.payload.text) || lang.tr('module.hitlnext.handoff.quickReply')
+        break
+      case 'carousel':
+        text = '🎠 ' + (lang.tr('module.hitlnext.handoff.carouselMessage') || 'Carousel')
+        break
+      default:
+        text = event.preview || lang.tr('module.hitlnext.handoff.unknownMessage')
+    }
+
+    if (!text) {
+      return lang.tr('module.hitlnext.handoff.noMessage')
+    }
+
+    // Truncate long messages to show a preview
+    return text.length > 80 ? `${text.substring(0, 80)}...` : text
+  }
+
   return (
     <div className={cx(styles.handoffItem)}>
-      <p>#{props.id}</p>
-      <p className="bp3-text-small bp3-text-muted">
-        {props.status} ⋅ {lang.tr('module.hitlnext.handoff.created', { date: fromNow })}
-      </p>
+      <div className={styles.info}>
+        <p>#{props.id}</p>
+        <p className="bp3-text-small bp3-text-muted">
+          {props.status} ⋅ {lang.tr('module.hitlnext.handoff.created', { date: fromNow })}
+        </p>
+        <p
+          className="bp3-text-small"
+          style={{ marginTop: '4px', color: '#666', fontStyle: 'italic', fontSize: '11px', lineHeight: '1.3' }}
+        >
+          {getLastMessageText()}
+        </p>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Resumen de los cambios realizados:

He modificado el módulo hitlnext para mostrar la última línea de la conversación en el preview de conversaciones pendientes. Los cambios principales incluyen:

### 1. **Backend (Repository.ts)**:
- Amplié el `recentEventQuery()` para capturar no solo mensajes de texto, sino también imágenes, archivos, audio, video, ubicación, quick_reply y carrusel
- Esto asegura que siempre se capture el último evento relevante de la conversación

### 2. **Frontend (HandoffItem.tsx)**:
- Agregué lógica para extraer y mostrar el texto del último mensaje
- Implementé manejo específico para diferentes tipos de eventos:
  - **Texto**: Muestra el contenido del mensaje
  - **Imagen**: Muestra "📷 Imagen"  
  - **Archivo**: Muestra "📎 Archivo"
  - **Audio**: Muestra "🎵 Audio"
  - **Video**: Muestra "🎥 Video"
  - **Ubicación**: Muestra "📍 Ubicación"
  - **Quick Reply**: Muestra el texto de la respuesta rápida
  - **Carrusel**: Muestra "🎠 Carrusel"
- Los mensajes largos se truncan a 80 caracteres con "..." al final
- Agregué estilos inline para que el preview se vea distintivo (color gris, cursiva, tamaño de fuente menor)

### 3. **Traducciones**:
- Agregué traducciones en inglés, español y francés para:
  - "noMessage": Cuando no hay mensaje disponible
  - Etiquetas para diferentes tipos de contenido (imagen, archivo, audio, etc.)

### 4. **Funcionalidad robusta**:
- El código maneja casos donde no hay evento o donde el evento no tiene contenido
- Fallback a mensajes por defecto cuando no se puede extraer información útil
- Compatibilidad con la estructura existente del módulo

Ahora, en el listado de conversaciones pendientes del lado izquierdo, cada conversación mostrará:
- El ID de la conversación
- El estado y fecha de creación  
- **La nueva línea de preview** con el contenido del último mensaje del usuario

Esto resuelve el problema donde el preview siempre mostraba el mismo mensaje antiguo, y ahora mostrará dinámicamente la última interacción entre el bot y el usuario para cada conversación pendiente.