### PR TITLE
Transfer Message Enabled Only For Reassignment Messages

### DIFF
--- a/modules/hitlnext/src/backend/api.ts
+++ b/modules/hitlnext/src/backend/api.ts
@@ -282,7 +282,7 @@ export default async (bp: typeof sdk, state: StateType, repository: Repository) 
 
       const configs: Config = await bp.config.getModuleConfigForBot(MODULE_NAME, req.params.botId)
 
-      if (configs.transferMessageEnabled && configs.assignMessage) {
+      if (configs.assignMessage) {
         const attributes = await bp.users.getAttributes(handoff.userChannel, handoff.userId)
         const language = attributes.language
 

--- a/modules/hitlnext/src/backend/service.ts
+++ b/modules/hitlnext/src/backend/service.ts
@@ -46,7 +46,7 @@ class Service {
       return handoff
     })
 
-    if (config.transferMessageEnabled && config.transferMessage) {
+    if (config.transferMessage) {
       await this.sendMessageToUser(config.transferMessage, eventDestination, language)
     }
 
@@ -136,7 +136,7 @@ class Service {
 
       // Send assignment message to user
       const config: Config = await this.bp.config.getModuleConfigForBot(MODULE_NAME, botId)
-      if (config.transferMessageEnabled && config.assignMessage) {
+      if (config.assignMessage) {
         const attributes = await this.bp.users.getAttributes(handoff.userChannel, handoff.userId)
         const language = attributes.language
         const eventDestination = toEventDestination(botId, handoff)

--- a/modules/hitlnext/src/config.ts
+++ b/modules/hitlnext/src/config.ts
@@ -52,7 +52,7 @@ export interface Config {
   autoAssignConversations: boolean
 
   /**
-   * @param transferMessageEnabled Whether or not to show transfer/reassignment messages to users
+   * @param transferMessageEnabled Whether or not to show reassignment messages to users. Transfer and assignment messages are always shown.
    * @default true
    */
   transferMessageEnabled: boolean


### PR DESCRIPTION
## ✅ Corrección Final Completada

### **Cambios Realizados:**

**Problema identificado:** Los mensajes de transferencia inicial (`transferMessage`) y asignación (`assignMessage`) estaban siendo controlados incorrectamente por `transferMessageEnabled`, cuando solo los mensajes de **reasignación** deberían ser controlados.

**Soluciones aplicadas:**

1. ✅ **service.ts - `createHandoff()`**: Removido control de `transferMessageEnabled` para `transferMessage`
2. ✅ **service.ts - `autoAssignHandoff()`**: Removido control de `transferMessageEnabled` para `assignMessage`  
3. ✅ **api.ts - asignación manual**: Removido control de `transferMessageEnabled` para `assignMessage`
4. ✅ **config.ts**: Actualizada documentación para aclarar que solo controla mensajes de reasignación
5. ✅ **Módulo compilado exitosamente** sin errores

### **Comportamiento Final Correcto:**

#### 🟢 **Mensajes que SIEMPRE se muestran (independientes de `transferMessageEnabled`):**
- ✅ `transferMessage` - "Se le está transfiriendo a un agente"
- ✅ `assignMessage` - "Ha sido asignado al agente {{agentName}}"
- ✅ `resolveMessage` - "Se le está transfiriendo de vuelta al bot"

#### 🔄 **Mensajes controlados por `transferMessageEnabled`:**

**Cuando `transferMessageEnabled = true`:**
- ✅ `reassignMessage` - "El agente {{agentName}} ha reasignado su conversación..."
- ✅ `reassignSuccessMessage` - "Su conversación ha sido reasignada al agente {{agentName}}"
- ✅ `reassignErrorMessage` - "Lo siento, hubo un error al reasignar..."

**Cuando `transferMessageEnabled = false`:**
- ❌ NO se muestran mensajes de reasignación (solo esos)

### **Resultado:**
Ahora solo los mensajes de **reasignación** (los problemáticos que se mostraban duplicados en la imagen) son controlados por `transferMessageEnabled`, mientras que los mensajes normales de transferencia y asignación inicial siguen funcionando normalmente para informar al usuario del estado de su conversación.

La funcionalidad está perfectamente configurada para resolver el problema específico de los mensajes duplicados de reasignación sin afectar la experiencia normal del usuario.