### PR TITLE
Hitl Multimedia Response When Paused

### DIFF
--- a/modules/hitl/src/backend/setup.ts
+++ b/modules/hitl/src/backend/setup.ts
@@ -50,7 +50,10 @@ export default async (bp: SDK, db: Database) => {
 
       const config = await bp.config.getModuleConfigForBot('hitl', event.botId)
 
-      if ((!!session.paused || config.paused) && _.includes(['text', 'message', 'quick_reply'], event.type)) {
+      if (
+        (!!session.paused || config.paused) &&
+        _.includes(['text', 'message', 'quick_reply', 'image', 'file', 'video', 'voice'], event.type)
+      ) {
         debugSwallow('message swallowed / session paused', {
           target: event.target,
           channel: event.channel,


### PR DESCRIPTION
✅ Problema Solucionado
He identificado y corregido el problema en el módulo hitl donde el bot respondía a imágenes y archivos multimedia incluso cuando la conversación estaba pausada.

🔍 Causa del Problema
En el archivo setup.ts, el middleware incomingHandler solo verificaba si el evento era de tipo text, message o quick_reply para pausar el procesamiento cuando la sesión estaba pausada (línea 56). No incluía los tipos multimedia como image, file, video o voice.

🔧 Solución Implementada
Modifiqué la línea 56 para incluir todos los tipos de eventos multimedia:

Antes:

if ((!!session.paused || config.paused) && _.includes(['text', 'message', 'quick_reply'], event.type))
Después:

if ((!!session.paused || config.paused) && _.includes(['text', 'message', 'quick_reply', 'image', 'file', 'video', 'voice'], event.type))
📦 Tipos de Eventos Ahora Cubiertos
✅ text - Mensajes de texto
✅ message - Mensajes generales
✅ quick_reply - Respuestas rápidas
✅ image - Imágenes (NUEVO)
✅ file - Archivos/Documentos (NUEVO)
✅ video - Videos (NUEVO)
✅ voice - Audios/Notas de voz (NUEVO)
✔️ Compilación Exitosa
El módulo hitl se compiló correctamente sin errores:


[hitl] Generated backend (3509 ms)[hitl] Generated frontend bundle (4633 ms)[module-builder] Build completedDone in 15.08s.
🎯 Resultado
Ahora cuando una conversación esté pausada en el módulo HITL:

El bot NO responderá a mensajes de texto ✅
El bot NO responderá a imágenes ✅
El bot NO responderá a archivos multimedia (videos, audios, documentos) ✅
Solo el agente podrá interactuar con el usuario ✅
Los eventos serán "swallowed" (detenidos) correctamente y se registrarán en los logs con el mensaje: "message swallowed / session paused".